### PR TITLE
chore: update synpase and prepare v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.2](https://github.com/ionic-team/capacitor-file-viewer/compare/v1.0.1...v1.0.2)
+
+- Set dependency on @capacitor/synapse to 1.0.3 to fix ssr environments
+
 # [1.0.1](https://github.com/ionic-team/capacitor-file-viewer/compare/v1.0.0...v1.0.1)
 
 - Fix(ios): Remove duplicate path separators that could cause files to not be found.

--- a/packages/capacitor-plugin/package-lock.json
+++ b/packages/capacitor-plugin/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@capacitor/file-viewer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@capacitor/file-viewer",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@capacitor/synapse": "^1.0.2"
+        "@capacitor/synapse": "^1.0.3"
       },
       "devDependencies": {
         "@capacitor/android": "^7.0.0",
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@capacitor/synapse": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.2.tgz",
-      "integrity": "sha512-ynq39s4D2rhk+aVLWKfKfMCz9SHPKijL9tq8aFL5dG7ik7/+PvBHmg9cPHbqdvFEUSMmaGzL6cIjzkOruW7vGA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.3.tgz",
+      "integrity": "sha512-7gGvuQ1NlSCwnjdIMkry+/meyUxHTnsVodRxOTOerLAoAyvtSnCp1rKyLjt9kCz9Lf7Y/wUbCe+AWbAvfxL5bA==",
       "license": "ISC"
     },
     "node_modules/@chevrotain/cst-dts-gen": {

--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capacitor/file-viewer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The FileViewer API provides mechanisms for opening files and previewing media. Not available on web.",
   "main": "./dist/plugin.cjs",
   "module": "./dist/plugin.mjs",
@@ -55,7 +55,7 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
-    "@capacitor/synapse": "^1.0.2"
+    "@capacitor/synapse": "^1.0.3"
   },
   "devDependencies": {
     "@capacitor/android": "^7.0.0",


### PR DESCRIPTION
## Description
This PR updates the `@capacitor/synapse` depedency to `1.0.3` which fixes a critical bug which prevented the plugin from running in SSR environments.


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)
