### PR TITLE
fix(ios): Use capacitor-swift-pm from 7.0.0 instead of specific version

### DIFF
--- a/packages/capacitor-plugin/Package.swift
+++ b/packages/capacitor-plugin/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["FileViewerPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "7.1.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "7.0.0")
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
Similarly to https://github.com/ionic-team/capacitor-file-transfer/pull/12

We were forcing a specific version for `capacitor-swift-pm` on the `Package.swift` file, which is not necessary - Fixed in this PR.