### PR TITLE
chore(cicd): Fix release github action

### DIFF
--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -12,6 +12,7 @@ permissions:
     contents: write
     issues: write
     deployments: write
+    id-token: write # to enable use of OIDC for npm provenance
 
 jobs:
   setup:

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - development
       - next
-      - main
   workflow_dispatch:
 
 permissions:

--- a/packages/capacitor-plugin/release.config.cjs
+++ b/packages/capacitor-plugin/release.config.cjs
@@ -8,7 +8,12 @@ module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    '@semantic-release/changelog',
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "../../CHANGELOG.md"
+      }
+    ],
     '@semantic-release/npm',
     [
       '@semantic-release/github',
@@ -18,16 +23,16 @@ module.exports = {
         releasedLabels: false,
         addReleases: 'bottom',
         releaseNotes: {
-          changelogFile: 'CHANGELOG.md',
-        },
-      },
+          changelogFile: '../../CHANGELOG.md'
+        }
+      }
     ],
     [
       '@semantic-release/git',
       {
-        assets: ['CHANGELOG.md', 'package.json'],
-        message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-      },
-    ],
-  ],
+        assets: ['../../CHANGELOG.md', 'package.json'],
+        message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
+      }
+    ]
+  ]
 };

--- a/packages/capacitor-plugin/release.config.cjs
+++ b/packages/capacitor-plugin/release.config.cjs
@@ -2,7 +2,7 @@ module.exports = {
   branches: [
     { name: 'main', channel: 'latest' },
     { name: 'next', channel: 'next', prerelease: true },
-    { name: 'dev', channel: 'dev', prerelease: true },
+    { name: 'development', channel: 'dev', prerelease: true },
   ],
   repositoryUrl: 'https://github.com/ionic-team/capacitor-file-viewer.git',
   plugins: [


### PR DESCRIPTION
Update release GitHub action in the following ways:

- Adding missing `id-token` permission.
- Correcting path to CHANGELOG.
- Correct branch name for dev tag releases.
- Not run automatically on push to main. The reason I changed this is because this way we can choose when to release a stable, in case we want to bundle multiple features / fixes. Releases are still running automatically for non-stable branches.