### PR TITLE
fix: export package.json to fix cap sync issues

### DIFF
--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/plugin.mjs",


### PR DESCRIPTION
Addresses https://github.com/ionic-team/capacitor-file-viewer/issues/3

Certain usages of this plugin inside monorepos can cause Capacitor CLI to not resolve the `package.json`, thus causing the plugin to not be discovered when running `cap sync` command.

A similar issue was reported for InAppBrowser - https://github.com/ionic-team/capacitor-os-inappbrowser/issues/59 + https://github.com/ionic-team/capacitor-os-inappbrowser/issues/27 - , and the fix was the same - https://github.com/ionic-team/capacitor-os-inappbrowser/pull/52