### PR TITLE
chore(ci): disable example app testing

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -40,30 +40,30 @@ jobs:
         working-directory: ./packages/capacitor-plugin
         run: npm run verify:ios
 
-  build-example-app-android:
-    needs: ['verify-plugin-ios', 'verify-plugin-android']
-    runs-on: 'macos-15'
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v5
-      - name: 'Setup Tools'
-        uses: ./.github/actions/setup-tools
-      - name: 'Prepare example app'
-        uses: ./.github/actions/prepare-example-app
-      - name: 'Build Android example app'
-        working-directory: ./packages/example-app-capacitor/android
-        run: ./gradlew clean assembleDebug
+#  build-example-app-android:
+#    needs: ['verify-plugin-ios', 'verify-plugin-android']
+#    runs-on: 'macos-15'
+#    timeout-minutes: 30
+#    steps:
+#      - uses: actions/checkout@v5
+#      - name: 'Setup Tools'
+#        uses: ./.github/actions/setup-tools
+#      - name: 'Prepare example app'
+#        uses: ./.github/actions/prepare-example-app
+#      - name: 'Build Android example app'
+#        working-directory: ./packages/example-app-capacitor/android
+#        run: ./gradlew clean assembleDebug
     
-  build-example-app-ios:
-    needs: ['verify-plugin-ios', 'verify-plugin-android']
-    runs-on: 'macos-15'
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v5
-      - name: 'Setup Tools'
-        uses: ./.github/actions/setup-tools
-      - name: 'Prepare example app'
-        uses: ./.github/actions/prepare-example-app
-      - name: 'Build iOS example app'
-        working-directory: ./packages/example-app-capacitor/ios/App
-        run: xcodebuild clean build -workspace App.xcworkspace -scheme App CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+#  build-example-app-ios:
+#    needs: ['verify-plugin-ios', 'verify-plugin-android']
+#    runs-on: 'macos-15'
+#    timeout-minutes: 30
+#    steps:
+#      - uses: actions/checkout@v5
+#      - name: 'Setup Tools'
+#        uses: ./.github/actions/setup-tools
+#      - name: 'Prepare example app'
+#        uses: ./.github/actions/prepare-example-app
+#      - name: 'Build iOS example app'
+#        working-directory: ./packages/example-app-capacitor/ios/App
+#        run: xcodebuild clean build -workspace App.xcworkspace -scheme App CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO


### PR DESCRIPTION
The example app is not configured to use the plugin, so disabling the building for now