### PR TITLE
fix(ios): bridge not initialized error message

### DIFF
--- a/packages/capacitor-plugin/README.md
+++ b/packages/capacitor-plugin/README.md
@@ -216,6 +216,6 @@ The plugin returns the following errors with specific codes on native Android an
 | OS-PLUG-FLVW-0008 | Android, iOS     | Could not open the file. |
 | OS-PLUG-FLVW-0009 | Android, iOS     | Invalid parameters. |
 | OS-PLUG-FLVW-0010 | Android          | There is no app to open this file. |
-| OS-PLUG-FLVW-0011 | iOS              | Cordova / Capacitor bridge isn’t initialized. |
+| OS-PLUG-FLVW-0011 | iOS              | Capacitor bridge isn’t initialized. |
 | OS-PLUG-FLVW-0012 | iOS              | The download failed. |
 | OS-PLUG-FLVW-0013 | iOS              | The file has no extension. |

--- a/packages/capacitor-plugin/ios/Sources/FileViewerPlugin/FileViewerError.swift
+++ b/packages/capacitor-plugin/ios/Sources/FileViewerPlugin/FileViewerError.swift
@@ -36,7 +36,7 @@ private extension FileViewerError {
         case .couldNotOpenDocument: "Could not open the document."
         case .downloadFailed: "The download failed."
         case .missingFileExtension: "The file has no extension."
-        case .bridgeNotInitialised: "Cordova bridge isn't initialized."
+        case .bridgeNotInitialised: "Capacitor bridge isn't initialized."
         }
     }
 }


### PR DESCRIPTION
The error message was mentioning cordova but it's obviously incorrect since this is a Capacitor Plugin (probably incorrectly copied when unifying with Cordova Plugin).